### PR TITLE
Use range dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 categories = ["cryptography::cryptocurrencies", "development-tools::testing"]
 
 [dependencies]
-bitcoincore-rpc = { version = "0.18.0" }
+bitcoincore-rpc = { version = ">= 0.18.0, <= 0.19.0" }
 log = "0.4"
 which = "4.2.5"
 anyhow = "1.0.66"
@@ -21,7 +21,7 @@ tempfile = "3"
 env_logger = "0.9.0"
 
 [build-dependencies]
-bitcoin_hashes = { version = "0.13", optional = true }
+bitcoin_hashes = { version = ">= 0.13, <= 0.14", optional = true }
 flate2 = { version = "1.0", optional = true }
 tar = { version = "0.4", optional = true }
 minreq = { version = "2.9.1", default-features = false, features = [


### PR DESCRIPTION
The latest `rust-bitcoin` release does not require any changes to use with this crate. If we use range dependencies for `bitcoin_hashes` and and `bitcoincore-rpc` then users can use this crate with whichever versions they want. Implies being able to use `rust-bitcoin` v0.31 or v0.32