### PR TITLE
Depend on `bitcoincore-rpc v0.19.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.36.0
+
+- Remove range dependencies for `bitcoincore-rpc` and depend on the
+  latest version `v0.19.0` [#163](https://github.com/rust-bitcoin/bitcoind/pull/163).
+
 ## 0.35.2
 
 - Use range dependencies for `bitcoincore-rpc` and `bitcoin_hashes`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoind"
-version = "0.35.2"
+version = "0.36.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>"]
 description = "Utility to run a regtest bitcoind process, useful in integration testing environment"
 license = "MIT"
@@ -11,7 +11,7 @@ edition = "2018"
 categories = ["cryptography::cryptocurrencies", "development-tools::testing"]
 
 [dependencies]
-bitcoincore-rpc = { version = ">= 0.17.0, <= 0.19" }
+bitcoincore-rpc = { version = "0.19", features = ["rand"] }
 log = "0.4"
 which = "4.2.5"
 anyhow = "1.0.66"


### PR DESCRIPTION
The latest `bitcoincore-rpc` is not compatible with earlier versions so we can no longer use a range dependency.
    
Upgrade to latest version of `bitcoincore-rpc` and remove the range dependency from crate manifest.
    
In preparation for release, add a changelog entry and bump the version.
 
